### PR TITLE
Forwarding scrollViewDidScroll: event to delegate

### DIFF
--- a/DCScrollView/DCScrollViewNavigationView.h
+++ b/DCScrollView/DCScrollViewNavigationView.h
@@ -19,6 +19,7 @@
 
 @optional
 - (void)dcscrollViewNavigationViewDidScroll:(DCScrollViewNavigationView *)navigationView;
+- (void)dcscrollViewNavigationViewWillBeginDragging:(DCScrollViewNavigationView *)navigationView;
 
 @end
 

--- a/DCScrollView/DCScrollViewNavigationView.m
+++ b/DCScrollView/DCScrollViewNavigationView.m
@@ -224,6 +224,9 @@
     if (self.focusedCenter) {
         [self changeCellsWithHighlited:NO];
     }
+    if ([self.delegate respondsToSelector:@selector(dcscrollViewNavigationViewWillBeginDragging:)]) {
+        [self.delegate dcscrollViewNavigationViewWillBeginDragging:self];
+    }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView


### PR DESCRIPTION
I added optional method `dcscrollViewNavigationViewDidScroll` into `DCScrollViewNavigationViewDelegate`.

I want to detect `scrollViewDidScroll` event on `DCScrollViewNavigationView`.
`DCScrollViewNavigationView` has property to access internal UIScrollView, but the scrollView already has delegate.

So, I added optional method to forward `scrollViewDidScroll` event.
