### PR TITLE
Added optional method to DCScrollViewContentViewDelegate

### DIFF
--- a/DCScrollView/DCScrollViewContentView.h
+++ b/DCScrollView/DCScrollViewContentView.h
@@ -22,6 +22,10 @@
 - (void)dcscrollViewContentView:(DCScrollViewContentView *)contentView didChangeVisibleCellAtIndex:(NSInteger)index;
 - (void)dcscrollViewContentViewDidScroll:(DCScrollViewContentView *)contentView;
 
+@optional
+- (void)dcscrollViewContentViewDidEndDecelerating:(DCScrollViewContentView *)contentView;
+- (void)dcscrollViewContentViewDidEndScrollingAnimation:(DCScrollViewContentView *)contentView;
+
 @end
 
 @interface DCScrollViewContentView : UIScrollView

--- a/DCScrollView/DCScrollViewContentView.m
+++ b/DCScrollView/DCScrollViewContentView.m
@@ -275,4 +275,18 @@
     [self.delegate dcscrollViewContentViewDidScroll:self];
 }
 
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+    if ([self.delegate respondsToSelector:@selector(dcscrollViewContentViewDidEndDecelerating:)]) {
+        [self.delegate dcscrollViewContentViewDidEndDecelerating:self];
+    }
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    if ([self.delegate respondsToSelector:@selector(dcscrollViewContentViewDidEndScrollingAnimation:)]) {
+        [self.delegate dcscrollViewContentViewDidEndScrollingAnimation:self];
+    }
+}
+
 @end


### PR DESCRIPTION
`DCScrollViewContentView` is subclass of `UIScrollView`, but it is also delegate of itself.

I want to detect some `UIScrollView` events, so I added some optional method into `DCScrollViewContentViewDelegate`.
